### PR TITLE
feat: add fork PR support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   ### Usually a bad idea / not recommended
   diff_branch:
     description: Branch to diff against, defaults to the default branch
-    default: ${{ github.event.repository.default_branch }}
+    default: ${{ github.event.pull_request.base.repo.default_branch }}
 
 outputs:
   triggered:
@@ -48,7 +48,7 @@ runs:
         TRIGGERS=${{ inputs.triggers }}
 
         # Add remote and fetch branch (treats forks and non-forks the same)
-        git remote add to_diff "${{ github.event.repository.clone_url }}"
+        git remote add to_diff "${{ github.event.pull_request.base.repo.clone_url }}"
         git fetch to_diff ${{ inputs.diff_branch }}
 
         while read -r check; do


### PR DESCRIPTION
## Summary
Adds fork PR support by unifying the checkout and diff logic. The action now works for both fork and non-fork PRs using the same code path, eliminating the need for explicit fork detection.

## Changes
- Always checkout PR head using `github.event.pull_request.head.repo.full_name` and `github.event.pull_request.head.sha`
- Always add base repo as `to_diff` remote using `github.event.pull_request.base.repo.clone_url` (fixes fork PRs in `pull_request_target` context)
- Use `github.event.pull_request.base.repo.default_branch` for default diff branch
- Unified code path handles both fork and non-fork PRs automatically
- Added `set -e` for fail-fast error handling
- Updated comments to clarify PR context requirement

## Behavior

### All PRs (fork and non-fork)
- Checks out PR head (works for both fork and non-fork PRs)
- Adds base repo as `to_diff` remote
- Fetches base repo's `diff_branch` from `to_diff` remote
- Compares PR HEAD vs `to_diff/diff_branch`

## Key Simplification
By always checking out the PR head and always adding the base repo as a remote, we eliminated the need for explicit fork detection. The same code path works for both scenarios.

## Testing
- [x] Verify backward compatibility with non-fork PRs (all tests passing)
- [ ] Test with fork PRs in `pull_request_target` context (requires merge first)
- [ ] Ensure trigger evaluation works correctly for both scenarios

## Notes
- No release will be cut until fork PR support is confirmed working
- Known issues documented in #24 (array handling) and #25 (pattern matching) - non-blocking