### PR TITLE
fix: improve trigger parsing, handle spaces

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,11 +45,13 @@ runs:
         fi
 
         # Build if changed files (git diff) match triggers
-        # Parse triggers input into array (handles space-separated values with parentheses/quotes)
+        # Parse triggers input into array (properly handles quoted strings with spaces)
         TRIGGERS_STR="${{ inputs.triggers }}"
-        # Remove parentheses and single quotes, then split by spaces into array
-        TRIGGERS_STR=$(sed "s/[()']//g" <<< "$TRIGGERS_STR")
-        IFS=' ' read -ra TRIGGERS <<< "$TRIGGERS_STR"
+        # Extract all quoted strings preserving spaces within quotes
+        TRIGGERS=()
+        while IFS= read -r line; do
+          [[ -n "$line" ]] && TRIGGERS+=("$line")
+        done < <(grep -o "'[^']*'" <<< "$TRIGGERS_STR" | sed "s/'//g")
 
         # Add remote and fetch branch (treats forks and non-forks the same)
         git remote add to_diff "${{ github.event.pull_request.base.repo.clone_url }}"


### PR DESCRIPTION
## Summary
Fixes #24 and #25 - Properly parse triggers input into a bash array and use prefix matching to prevent false positives.

## Problems

### Issue #24: Array Handling
The triggers input was assigned as a string but used as an array:
```bash
TRIGGERS=${{ inputs.triggers }}
for t in "${TRIGGERS[@]}"; do
```

This caused all trigger paths to be treated as a single element instead of being parsed individually. Additionally, trigger paths containing spaces would be incorrectly split.

### Issue #25: Pattern Matching False Positives
The pattern matching used quoted regex, causing substring matching:
```bash
if [[ "${check}" =~ "${t}" ]]; then
```

This caused false positives. For example:
- Trigger: `./backend/`
- File: `./some-backend-file.txt` → **matches** (false positive)
- File: `./old-backend-stuff/config.yml` → **matches** (false positive)

## Solutions

### Array Parsing (#24)
- Extract quoted strings using `grep -o` to preserve spaces within quotes
- Remove quotes from extracted strings using `sed`
- Each trigger path is now properly iterated over as a separate array element
- Trigger paths with spaces (e.g., `'my path/file'`) are now correctly handled

### Pattern Matching (#25)
- Changed from regex substring matching to prefix matching
- Changed from: `[[ "${check}" =~ "${t}" ]]`
- Changed to: `[[ "$check" == "$t"* ]]`
- Now `./backend/` matches `./backend/file.txt` but NOT `./some-backend-file.txt`

## Implementation Details
1. **Array parsing**: Extract quoted strings preserving spaces
2. **Here-string improvement**: Use `<<<` instead of echo pipe
3. **Pattern matching**: Use prefix matching for accurate path matching

## Testing
- [x] All existing tests pass
- [x] Fork PR support validated (PR created from fork)
- [ ] Manual testing with trigger paths containing spaces
- [ ] Manual testing to verify no false positives with prefix matching