### PR TITLE
fix: git remote base URL handling logic

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ runs:
         if git remote get-url base >/dev/null 2>&1; then
           git remote set-url base "$BASE_REMOTE_URL"
         else
-          git remote add base "$BASE_REMOTE_URL" || git remote set-url base "$BASE_REMOTE_URL"
+          git remote add base "$BASE_REMOTE_URL" 2>/dev/null || git remote set-url base "$BASE_REMOTE_URL"
         fi
         
         # If BASE_REF starts with HEAD, it's a local ref - use it directly

--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,7 @@ runs:
         if git remote get-url base >/dev/null 2>&1; then
           git remote set-url base "$BASE_REMOTE_URL"
         else
-          git remote add base "$BASE_REMOTE_URL"
+          git remote add base "$BASE_REMOTE_URL" || git remote set-url base "$BASE_REMOTE_URL"
         fi
         
         # If BASE_REF starts with HEAD, it's a local ref - use it directly


### PR DESCRIPTION
Modify remote base URL handling to set URL if already exists.