### PR TITLE
feat: support private repos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   ref:
     description: Reference to compare against (e.g., 'main', 'HEAD^', commit SHA). Defaults to base repo default branch for PRs, or HEAD^ for non-PR events. Local refs (HEAD^, HEAD~2) work for non-PR events; remote refs (branches, tags, SHAs) work for all events
     required: false
+  token:
+    description: Specify token (GH or PAT), instead of inheriting one from the calling workflow
+    default: ${{ github.token }}
 
   annotations:
     description: Emit workflow summary annotations (`::notice::`) for fired/not fired results. Set to false to suppress annotations
@@ -33,7 +36,7 @@ runs:
     # Checkout appropriate ref based on event type
     - uses: actions/checkout@v6
       with:
-        token: ${{ github.token }}
+        token: ${{ inputs.token }}
         repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
         # Fetch all commits for non-PR events (defaults to 1 for PRs)

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,7 @@ runs:
     # Checkout appropriate ref based on event type
     - uses: actions/checkout@v6
       with:
+        token: ${{ github.token }}
         repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
         # Fetch all commits for non-PR events (defaults to 1 for PRs)


### PR DESCRIPTION
## Summary

Add explicit `token: ${{ github.token }}` to the `actions/checkout@v6` step.

## Why

When `action-diff-triggers` is called from a private repository (via a reusable workflow in another repo), the implicit `${{ github.token }}` may not properly resolve in the composite action context. Adding the explicit token parameter ensures checkout works reliably even in private-repo scenarios where the caller has granted `contents: read` permission.

This is part of fixing the broader issue where private-repo consumers of bcgov reusable workflows encounter checkout failures.

## Changes

- Line 35: Add `token: ${{ github.token }}` as first parameter in checkout with: block

Relates to bcgov/quickstart-openshift-helpers#247