### PR TITLE
feat(annotations): improve visibility with job name and trigger list

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,10 +54,10 @@ runs:
         # Always fire if triggers are omitted
         if [ -z "${{ inputs.triggers }}" ]; then
           echo "::group::Diff Triggers — ✅ TRIGGERED | ${{ github.repository }} $CALLER_CONTEXT"
-          echo "  Triggers: (omitted — always fires)"
+          echo "  Triggers: (omitted, always fires)"
           echo "::endgroup::"
           if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
-            echo "::notice title=Diff Triggers [${{ github.job }}]::✅ Omitted (always fires)"
+            echo "::notice title=Diff Triggers [${{ github.job }}]::✅ Omitted (always fires)."
           fi
           echo "triggered=true" >> $GITHUB_OUTPUT
           exit 0

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
           echo "  Triggers: (omitted — always fires)"
           echo "::endgroup::"
           if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
-            echo "::notice title=Diff Triggers [${{ github.job }}]::✅ Diff Triggers fired. Triggers: (omitted — always fires)"
+            echo "::notice title=Diff Triggers [${{ github.job }}]::✅ Omitted"
           fi
           echo "triggered=true" >> $GITHUB_OUTPUT
           exit 0
@@ -129,7 +129,7 @@ runs:
           echo "$DETAILS_LOG"
           echo "::endgroup::"
           if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
-            echo "::notice title=Diff Triggers [${{ github.job }}]::✅ Diff Triggers fired. Triggers: $TRIGGERS_STR"
+            echo "::notice title=Diff Triggers [${{ github.job }}]::✅ Fired. Triggers: $TRIGGERS_STR"
           fi
           echo "triggered=true" >> $GITHUB_OUTPUT
         else
@@ -141,7 +141,7 @@ runs:
           echo "$DETAILS_LOG"
           echo "::endgroup::"
           if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
-            echo "::notice title=Diff Triggers [${{ github.job }}]::🔍 Diff Triggers not fired. Triggers: $TRIGGERS_STR"
+            echo "::notice title=Diff Triggers [${{ github.job }}]::🔍 Not fired. Triggers: $TRIGGERS_STR"
           fi
           echo "triggered=false" >> $GITHUB_OUTPUT
         fi

--- a/action.yml
+++ b/action.yml
@@ -141,7 +141,7 @@ runs:
           echo "$DETAILS_LOG"
           echo "::endgroup::"
           if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
-            echo "::notice title=Diff Triggers [${{ github.job }}]::🔍 Not fired. Triggers: $TRIGGERS_STR"
+            echo "::notice title=Diff Triggers [${{ github.job }}]::⊘ Not fired. Triggers: $TRIGGERS_STR"
           fi
           echo "triggered=false" >> $GITHUB_OUTPUT
         fi

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
           echo "  Triggers: (omitted — always fires)"
           echo "::endgroup::"
           if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
-            echo "::notice title=Diff Triggers::✅ Diff Triggers fired. (${{ github.repository }})"
+            echo "::notice title=Diff Triggers [${{ github.job }}]::✅ Diff Triggers fired. Triggers: (omitted — always fires)"
           fi
           echo "triggered=true" >> $GITHUB_OUTPUT
           exit 0
@@ -129,7 +129,7 @@ runs:
           echo "$DETAILS_LOG"
           echo "::endgroup::"
           if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
-            echo "::notice title=Diff Triggers::✅ Diff Triggers fired. (${{ github.repository }})"
+            echo "::notice title=Diff Triggers [${{ github.job }}]::✅ Diff Triggers fired. Triggers: $TRIGGERS_STR"
           fi
           echo "triggered=true" >> $GITHUB_OUTPUT
         else
@@ -141,7 +141,7 @@ runs:
           echo "$DETAILS_LOG"
           echo "::endgroup::"
           if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
-            echo "::notice title=Diff Triggers::ℹ️ Diff Triggers not fired. (${{ github.repository }})"
+            echo "::notice title=Diff Triggers [${{ github.job }}]::🔍 Diff Triggers not fired. Triggers: $TRIGGERS_STR"
           fi
           echo "triggered=false" >> $GITHUB_OUTPUT
         fi

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
           echo "  Triggers: (omitted — always fires)"
           echo "::endgroup::"
           if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
-            echo "::notice title=Diff Triggers [${{ github.job }}]::✅ Fired (triggers omitted — always fires)"
+            echo "::notice title=Diff Triggers [${{ github.job }}]::✅ Omitted (always fires)"
           fi
           echo "triggered=true" >> $GITHUB_OUTPUT
           exit 0

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
           echo "  Triggers: (omitted — always fires)"
           echo "::endgroup::"
           if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
-            echo "::notice title=Diff Triggers [${{ github.job }}]::✅ Omitted"
+            echo "::notice title=Diff Triggers [${{ github.job }}]::✅ Fired (triggers omitted — always fires)"
           fi
           echo "triggered=true" >> $GITHUB_OUTPUT
           exit 0
@@ -66,6 +66,10 @@ runs:
         # Build if changed files (git diff) match triggers
         # Parse triggers input into array (properly handles quoted strings with spaces)
         TRIGGERS_STR="${{ inputs.triggers }}"
+        # Escape %, \n, \r for GitHub Actions workflow command encoding
+        ESCAPED_TRIGGERS="${TRIGGERS_STR//%/%25}"
+        ESCAPED_TRIGGERS="${ESCAPED_TRIGGERS//$'\n'/%0A}"
+        ESCAPED_TRIGGERS="${ESCAPED_TRIGGERS//$'\r'/%0D}"
         # Extract all quoted strings preserving spaces within quotes
         TRIGGERS=()
         while IFS= read -r line; do
@@ -129,7 +133,7 @@ runs:
           echo "$DETAILS_LOG"
           echo "::endgroup::"
           if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
-            echo "::notice title=Diff Triggers [${{ github.job }}]::✅ Fired. Triggers: $TRIGGERS_STR"
+            echo "::notice title=Diff Triggers [${{ github.job }}]::✅ Fired. Triggers: $ESCAPED_TRIGGERS"
           fi
           echo "triggered=true" >> $GITHUB_OUTPUT
         else
@@ -141,7 +145,7 @@ runs:
           echo "$DETAILS_LOG"
           echo "::endgroup::"
           if [[ "$ANNOTATIONS_ENABLED" == "true" ]]; then
-            echo "::notice title=Diff Triggers [${{ github.job }}]::⊘ Not fired. Triggers: $TRIGGERS_STR"
+            echo "::notice title=Diff Triggers [${{ github.job }}]::⊘ Not fired. Triggers: $ESCAPED_TRIGGERS"
           fi
           echo "triggered=false" >> $GITHUB_OUTPUT
         fi


### PR DESCRIPTION
This PR adds the job ID to the notice annotation titles, includes the escaped trigger list in the messages, removes the redundant repository suffix, and updates the not-fired status icon to the ⊘ symbol.